### PR TITLE
Add a joke to the README's Obligatory Jokes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,3 +259,7 @@ Because it dereferenced a pointer it inherited without ever asking where it came
 Why is the Ballr compiler such a good listener?
 
 Because it takes everything you pipe at it through stdin, never interrupts until you're done, and only then tells you everything you got wrong. 🎧
+
+Why does the Ballr test suite read like a cry for help?
+
+Because half of `tests/` is named `fail-something`, and `testall.log` cheerfully stamps `###### SUCCESS` under every single one of them. ✅


### PR DESCRIPTION
Adds one joke to the existing `Obligatory Jokes` section of the README.

That section already has ~50 entries in a question / blank line / punchline-with-emoji format, so this follows the existing convention rather than introducing a new one.

> Why does the Ballr test suite read like a cry for help?
>
> Because half of `tests/` is named `fail-something`, and `testall.log` cheerfully stamps `###### SUCCESS` under every single one of them. ✅

It also happens to be accurate: 38 of the 72 `.blr` files in `tests/` are named `fail-*`, and the committed `testall.log` prints `###### SUCCESS` after each of them.

**Scope:** one file, four added lines, no deletions. No changes to the compiler source, tests, build configuration, or dependencies.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKxrtG8SJZN3KbnzFYFkKt)_